### PR TITLE
Add index.js - allows require('angular.validators') to work

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./angular.validators.js');
+module.exports = 'angular.validators';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "angular.validators",
   "version": "4.4.2",
   "license": "MIT",
+  "main": "index.js",
   "devDependencies": {
     "chai": "^3.2.0",
     "grunt": "^0.4.5",


### PR DESCRIPTION
this is in line with other angular libraries - when required via `require('library')`, they register themselves on the global angular object, and export the angular module name

---

Examples:

[angular-animate](https://github.com/angular/bower-angular-animate/blob/master/index.js)
[angular-gettext](https://github.com/rubenv/angular-gettext/blob/master/index.js)
